### PR TITLE
Handle tree queryset .values() correctly

### DIFF
--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -151,6 +151,16 @@ class Test(TestCase):
     def test_values(self):
         tree = self.create_tree()
         self.assertEqual(
+            list(Model.objects.ancestors(tree.child2_1).values()),
+            [
+                {'custom_id': 1, 'name': 'root', 'order': 0, 'parent_id': None},
+                {'custom_id': 3, 'name': '2', 'order': 1, 'parent_id': 1},
+            ],
+        )
+
+    def test_values_list(self):
+        tree = self.create_tree()
+        self.assertEqual(
             list(
                 Model.objects.ancestors(tree.child2_1).values_list("parent", flat=True)
             ),

--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -153,8 +153,18 @@ class Test(TestCase):
         self.assertEqual(
             list(Model.objects.ancestors(tree.child2_1).values()),
             [
-                {'custom_id': 1, 'name': 'root', 'order': 0, 'parent_id': None},
-                {'custom_id': 3, 'name': '2', 'order': 1, 'parent_id': 1},
+                {
+                    "custom_id": tree.root.pk,
+                    "name": "root",
+                    "order": 0,
+                    "parent_id": None,
+                },
+                {
+                    "custom_id": tree.child2.pk,
+                    "name": "2",
+                    "order": 1,
+                    "parent_id": tree.root.pk,
+                },
             ],
         )
 

--- a/tree_queries/compiler.py
+++ b/tree_queries/compiler.py
@@ -210,12 +210,14 @@ class TreeCompiler(SQLCompiler):
         # I am not confident that this is the perfect way to approach this
         # problem but I just gotta stop worrying and trust the testsuite.
         skip_tree_fields = (
-            self.query.distinct and self.query.subquery
-        ) or any(  # pragma: no branch
-            # OK if generator is not consumed completely
-            annotation.is_summary
-            for alias, annotation in self.query.annotations.items()
-        ) or self.query.values_select
+            (self.query.distinct and self.query.subquery)
+            or self.query.values_select
+            or any(  # pragma: no branch
+                # OK if generator is not consumed completely
+                annotation.is_summary
+                for alias, annotation in self.query.annotations.items()
+            )
+        )
         opts = _find_tree_model(self.query.model)._meta
 
         params = {

--- a/tree_queries/compiler.py
+++ b/tree_queries/compiler.py
@@ -215,7 +215,7 @@ class TreeCompiler(SQLCompiler):
             # OK if generator is not consumed completely
             annotation.is_summary
             for alias, annotation in self.query.annotations.items()
-        )
+        ) or self.query.values_select
         opts = _find_tree_model(self.query.model)._meta
 
         params = {


### PR DESCRIPTION
Thanks for this great library!

We had a report (https://github.com/nautobot/nautobot/issues/4812) that doing a `.values()` call on a tree queryset was returning mixed-up data where the values were being reported for the wrong fields, i.e. instead of `{field_a: value_a, field_b: value_b, field_c: value_c, field_d: value_d}` we were getting `{field_a: <tree_depth>, field_b: <tree_path>, field_c: <tree_ordering>, field_d: value_a}`.

The attached change appears to fix the issue, and I've added a corresponding test case.