### PR TITLE
Handle tree queryset .values() even more correctly

### DIFF
--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -151,6 +151,20 @@ class Test(TestCase):
     def test_values(self):
         tree = self.create_tree()
         self.assertEqual(
+            list(Model.objects.with_tree_fields().values("name")),
+            [
+                {"name": "root"},
+                {"name": "1"},
+                {"name": "1-1"},
+                {"name": "2"},
+                {"name": "2-1"},
+                {"name": "2-2"},
+            ],
+        )
+
+    def test_values_ancestors(self):
+        tree = self.create_tree()
+        self.assertEqual(
             list(Model.objects.ancestors(tree.child2_1).values()),
             [
                 {
@@ -169,6 +183,13 @@ class Test(TestCase):
         )
 
     def test_values_list(self):
+        tree = self.create_tree()
+        self.assertEqual(
+            list(Model.objects.with_tree_fields().values_list("name", flat=True)),
+            ["root", "1", "1-1", "2", "2-1", "2-2"],
+        )
+
+    def test_values_list_ancestors(self):
         tree = self.create_tree()
         self.assertEqual(
             list(

--- a/tree_queries/compiler.py
+++ b/tree_queries/compiler.py
@@ -211,7 +211,6 @@ class TreeCompiler(SQLCompiler):
         # problem but I just gotta stop worrying and trust the testsuite.
         skip_tree_fields = (
             (self.query.distinct and self.query.subquery)
-            or self.query.values_select
             or any(  # pragma: no branch
                 # OK if generator is not consumed completely
                 annotation.is_summary
@@ -244,9 +243,9 @@ class TreeCompiler(SQLCompiler):
 
             self.query.add_extra(
                 # Do not add extra fields to the select statement when it is a
-                # summary query
+                # summary query or when using .values() or .values_list()
                 select={}
-                if skip_tree_fields
+                if skip_tree_fields or self.query.values_select
                 else {
                     "tree_depth": "__tree.tree_depth",
                     "tree_path": "__tree.tree_path",


### PR DESCRIPTION
Follow-on to #57, sorry for the trouble!

This changes the logic so that we still preserve tree traversal order when using `.values()` or `.values_list()` on it, while not reintroducing the issue that #57 was addressing.