### PR TITLE
Add support for descending sibling ordering, multi-field sibling ordering, and related field sibling ordering

### DIFF
--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -122,3 +122,17 @@ class InheritAbstractChildModel(InheritParentModel):
 
 class InheritConcreteGrandChildModel(InheritAbstractChildModel):
     pass
+
+
+class RelatedOrderModel(TreeNode):
+    name = models.CharField(max_length=100)
+
+
+class OneToOneRelatedOrder(models.Model):
+    relatedmodel = models.OneToOneField(
+        RelatedOrderModel,
+        on_delete=models.CASCADE,
+        primary_key=True,
+        related_name="related",
+    )
+    order = models.PositiveIntegerField(default=0)

--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -57,7 +57,8 @@ class Test(TestCase):
 
     def test_attributes(self):
         tree = self.create_tree()
-        child2_2 = Model.objects.with_tree_fields().get(pk=tree.child2_2.pk)
+        # Ordering should be deterministic
+        child2_2 = Model.objects.with_tree_fields().order_siblings_by("order", "pk").get(pk=tree.child2_2.pk)
         self.assertEqual(child2_2.tree_depth, 2)
         # Tree ordering is an array of the ranks assigned to a comment's
         # ancestors when they are ordered without respect for tree relations.

--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -19,6 +19,8 @@ from testapp.models import (
     TreeNodeIsOptional,
     UnorderedModel,
     UUIDModel,
+    RelatedOrderModel,
+    OneToOneRelatedOrder,
 )
 from tree_queries.compiler import SEPARATOR, TreeQuery
 from tree_queries.query import pk
@@ -57,7 +59,9 @@ class Test(TestCase):
         tree = self.create_tree()
         child2_2 = Model.objects.with_tree_fields().get(pk=tree.child2_2.pk)
         self.assertEqual(child2_2.tree_depth, 2)
-        self.assertEqual(child2_2.tree_ordering, [0, 1, 1])
+        # Tree ordering is an array of the ranks assigned to a comment's
+        # ancestors when they are ordered without respect for tree relations.
+        self.assertEqual(child2_2.tree_ordering, [1, 5, 6])
         self.assertEqual(
             child2_2.tree_path, [tree.root.pk, tree.child2.pk, tree.child2_2.pk]
         )
@@ -310,6 +314,7 @@ class Test(TestCase):
             Model.objects.create(parent=root, name=f"Node {i}", order=i * 10)
 
         positions = [m.order for m in Model.objects.with_tree_fields()]
+
         self.assertEqual(positions, sorted(positions))
 
     def test_bfs_ordering(self):
@@ -648,4 +653,91 @@ class Test(TestCase):
             [
                 ("child2_2", [1, 3, 6]),
             ],
+        )
+
+    def test_descending_order(self):
+        tree = self.create_tree()
+
+        nodes = Model.objects.order_siblings_by("-order")
+        self.assertEqual(
+            list(nodes),
+            [
+                tree.root,
+                tree.child2,
+                tree.child2_2,
+                tree.child2_1,
+                tree.child1,
+                tree.child1_1,
+            ],
+        )
+
+    def test_multi_field_order(self):
+        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+
+        tree.root = MultiOrderedModel.objects.create(name="root")
+        tree.child1 = MultiOrderedModel.objects.create(
+            parent=tree.root, first_position=0, second_position=1, name="1"
+        )
+        tree.child2 = MultiOrderedModel.objects.create(
+            parent=tree.root, first_position=0, second_position=0, name="2"
+        )
+        tree.child1_1 = MultiOrderedModel.objects.create(
+            parent=tree.child1, first_position=1, second_position=1, name="1-1"
+        )
+        tree.child2_1 = MultiOrderedModel.objects.create(
+            parent=tree.child2, first_position=0, second_position=1, name="2-1"
+        )
+        tree.child2_2 = MultiOrderedModel.objects.create(
+            parent=tree.child2, first_position=1, second_position=0, name="2-2"
+        )
+
+        nodes = MultiOrderedModel.objects.order_siblings_by("first_position", "-second_position")
+        self.assertEqual(
+            list(nodes),
+            [
+                tree.root,
+                tree.child1,
+                tree.child1_1,
+                tree.child2,
+                tree.child2_1,
+                tree.child2_2,
+            ]
+        )
+
+    def test_order_by_related(self):
+        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+
+        tree.root = RelatedOrderModel.objects.create(name="root")
+        tree.child1 = RelatedOrderModel.objects.create(parent=tree.root, name="1")
+        tree.child1_related = OneToOneRelatedOrder.objects.create(
+            relatedmodel=tree.child1, order=0
+        )
+        tree.child2 = RelatedOrderModel.objects.create(parent=tree.root, name="2")
+        tree.child2_related = OneToOneRelatedOrder.objects.create(
+            relatedmodel=tree.child2, order=1
+        )
+        tree.child1_1 = RelatedOrderModel.objects.create(parent=tree.child1, name="1-1")
+        tree.child1_1_related = OneToOneRelatedOrder.objects.create(
+            relatedmodel=tree.child1_1, order=0
+        )
+        tree.child2_1 = RelatedOrderModel.objects.create(parent=tree.child2, name="2-1")
+        tree.child2_1_related = OneToOneRelatedOrder.objects.create(
+            relatedmodel=tree.child2_1, order=0
+        )
+        tree.child2_2 = RelatedOrderModel.objects.create(parent=tree.child2, name="2-2")
+        tree.child2_2_related = OneToOneRelatedOrder.objects.create(
+            relatedmodel=tree.child2_2, order=1
+        )
+
+        nodes = RelatedOrderModel.objects.order_siblings_by("related__order")
+        self.assertEqual(
+            list(nodes),
+            [
+                tree.root,
+                tree.child1,
+                tree.child1_1,
+                tree.child2,
+                tree.child2_1,
+                tree.child2_2,
+            ]
         )

--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -314,7 +314,6 @@ class Test(TestCase):
             Model.objects.create(parent=root, name=f"Node {i}", order=i * 10)
 
         positions = [m.order for m in Model.objects.with_tree_fields()]
-
         self.assertEqual(positions, sorted(positions))
 
     def test_bfs_ordering(self):

--- a/tree_queries/compiler.py
+++ b/tree_queries/compiler.py
@@ -299,8 +299,6 @@ class TreeCompiler(SQLCompiler):
                 if _ordered_by_integer(opts, params)
                 else self.CTE_MYSQL_WITH_TEXT_ORDERING
             )
-        if params["order_by"]:
-            params["order_by"] = self.connection.ops.quote_name(params["order_by"])
         sql_0, sql_1 = super().as_sql(*args, **kwargs)
         explain = ""
         if sql_0.startswith("EXPLAIN "):

--- a/tree_queries/compiler.py
+++ b/tree_queries/compiler.py
@@ -194,16 +194,17 @@ class TreeCompiler(SQLCompiler):
         opts = self.query.model._meta
         sibling_order = self.query.get_sibling_order()
 
-        order_by_objs = []
-        if isinstance(sibling_order, str):
-            for order_obj, is_ref in self.find_ordering_name(sibling_order, opts, alias='t'):
-                order_by_objs.append(order_obj)
-        elif isinstance(sibling_order, list):
-            for field in self.query.sibling_order:
-                for order_obj, is_ref in self.find_ordering_name(field, opts, alias='t'):
-                    order_by_objs.append(order_obj)
+        if isinstance(sibling_order, list):
+            order_fields = sibling_order
+        elif isinstance(sibling_order, str):
+            order_fields = [sibling_order]
         else:
             raise ValueError("Sibling order must be a string or list of strings.")
+        
+        order_by_objs = []
+        for field in order_fields:
+            for order_obj, is_ref in self.find_ordering_name(field, opts, alias='t'):
+                order_by_objs.append(order_obj)
 
         row_window = Window(expression=RowNumber(), order_by=order_by_objs)
         order_sql, order_params = self.compile(row_window)

--- a/tree_queries/compiler.py
+++ b/tree_queries/compiler.py
@@ -194,12 +194,12 @@ class TreeCompiler(SQLCompiler):
         opts = self.query.model._meta
         sibling_order = self.query.get_sibling_order()
 
-        if isinstance(sibling_order, list):
+        if isinstance(sibling_order, (list, tuple)):
             order_fields = sibling_order
         elif isinstance(sibling_order, str):
             order_fields = [sibling_order]
         else:
-            raise ValueError("Sibling order must be a string or list of strings.")
+            raise ValueError("Sibling order must be a string or a list or tuple of strings.")
         
         order_by_objs = []
         for field in order_fields:

--- a/tree_queries/query.py
+++ b/tree_queries/query.py
@@ -37,7 +37,7 @@ class TreeQuerySet(models.QuerySet):
         """
         return self.with_tree_fields(tree_fields=False)
 
-    def order_siblings_by(self, order_by):
+    def order_siblings_by(self, *order_by):
         """
         Sets TreeQuery sibling_order attribute
 

--- a/tree_queries/query.py
+++ b/tree_queries/query.py
@@ -41,8 +41,8 @@ class TreeQuerySet(models.QuerySet):
         """
         Sets TreeQuery sibling_order attribute
 
-        Pass the name of a single model field as a string
-        to order tree siblings by that model field
+        Pass the names of model fields as a list of strings
+        to order tree siblings by those model fields
         """
         self.query.__class__ = TreeQuery
         self.query.sibling_order = order_by


### PR DESCRIPTION
Addresses #6.

Uses the `ROW_NUMBER()` window expression to map any ordering criteria onto an ascending set of ordinal integers which can be used to properly order a tree.

Parameters for this new ordering method are generated by `get_sibling_order_params()` which uses the base Django `SQLCompiler` to convert a dummy Django queryset object to SQL. This way we are able to rely on Django's backend to generate the extra SQL needed for more complex orderings like ordering by a related field.

This change will also make supporting additional forms of ordering simpler. For example, ordering based on annotations is not currently supported. However, it could be added by having `TreeQuerySet` override the base `annotate()` method so that it additionally stores its initial `args` and `kwargs` as instance variables which can later be submitted to the dummy queryset used to generate ordering parameters.