### PR TITLE
Add the ability to filter queries before construction of the CTE

### DIFF
--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -25,11 +25,13 @@ from testapp.models import (
 from tree_queries.compiler import SEPARATOR, TreeQuery
 from tree_queries.query import pk
 
+from types import SimpleNamespace
+
 
 @override_settings(DEBUG=True)
 class Test(TestCase):
     def create_tree(self):
-        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+        tree = SimpleNamespace()
         tree.root = Model.objects.create(name="root")
         tree.child1 = Model.objects.create(parent=tree.root, order=0, name="1")
         tree.child2 = Model.objects.create(parent=tree.root, order=1, name="2")
@@ -257,7 +259,7 @@ class Test(TestCase):
         self.assertNotIn("root", html)
 
     def test_string_ordering(self):
-        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+        tree = SimpleNamespace()
 
         tree.americas = StringOrderedModel.objects.create(name="Americas")
         tree.europe = StringOrderedModel.objects.create(name="Europe")
@@ -373,7 +375,7 @@ class Test(TestCase):
     def test_reference(self):
         tree = self.create_tree()
 
-        references = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+        references = SimpleNamespace()
         references.none = ReferenceModel.objects.create(position=0)
         references.root = ReferenceModel.objects.create(
             position=1, tree_field=tree.root
@@ -534,7 +536,7 @@ class Test(TestCase):
         )
 
     def test_sibling_ordering(self):
-        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+        tree = SimpleNamespace()
 
         tree.root = MultiOrderedModel.objects.create(name="root")
         tree.child1 = MultiOrderedModel.objects.create(
@@ -682,7 +684,7 @@ class Test(TestCase):
         )
 
     def test_multi_field_order(self):
-        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+        tree = SimpleNamespace()
 
         tree.root = MultiOrderedModel.objects.create(name="root")
         tree.child1 = MultiOrderedModel.objects.create(
@@ -717,7 +719,7 @@ class Test(TestCase):
         )
 
     def test_order_by_related(self):
-        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+        tree = SimpleNamespace()
 
         tree.root = RelatedOrderModel.objects.create(name="root")
         tree.child1 = RelatedOrderModel.objects.create(parent=tree.root, name="1")
@@ -798,7 +800,7 @@ class Test(TestCase):
         )
 
     def test_tree_filter_related(self):
-        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+        tree = SimpleNamespace()
 
         tree.root = RelatedOrderModel.objects.create(name="root")
         tree.root_related = OneToOneRelatedOrder.objects.create(
@@ -836,7 +838,7 @@ class Test(TestCase):
         )
 
     def test_tree_filter_with_order(self):
-        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+        tree = SimpleNamespace()
 
         tree.root = MultiOrderedModel.objects.create(
             name="root", first_position=1,
@@ -888,7 +890,7 @@ class Test(TestCase):
         )
 
     def test_tree_filter_Q_mix(self):
-        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+        tree = SimpleNamespace()
 
         tree.root = MultiOrderedModel.objects.create(
             name="root", first_position=1, second_position=2

--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -753,3 +753,121 @@ class Test(TestCase):
                 tree.child2_2,
             ],
         )
+
+    def test_pre_exclude(self):
+        tree = self.create_tree()
+        # Pre-filter should remove children if
+        # the parent meets the filtering criteria
+        nodes = Model.objects.pre_exclude(name="2")
+        self.assertEqual(
+            list(nodes),
+            [
+                tree.root,
+                tree.child1,
+                tree.child1_1,
+            ],
+        )
+
+    def test_pre_filter(self):
+        tree = self.create_tree()
+        # Pre-filter should remove children if
+        # the parent does not meet the filtering criteria
+        nodes = Model.objects.pre_filter(name__in=["root","1-1","2","2-1","2-2"])
+        self.assertEqual(
+            list(nodes),
+            [
+                tree.root,
+                tree.child2,
+                tree.child2_1,
+                tree.child2_2,
+            ],
+        )
+
+    def test_pre_filter_chaining(self):
+        tree = self.create_tree()
+        # Pre-filter should remove children if
+        # the parent does not meet the filtering criteria
+        nodes = Model.objects.pre_exclude(name="2-2").pre_filter(name__in=["root","1-1","2","2-1","2-2"])
+        self.assertEqual(
+            list(nodes),
+            [
+                tree.root,
+                tree.child2,
+                tree.child2_1,
+            ],
+        )
+
+    def test_pre_filter_related(self):
+        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+
+        tree.root = RelatedOrderModel.objects.create(name="root")
+        tree.root_related = OneToOneRelatedOrder.objects.create(
+            relatedmodel=tree.root, order=0
+        )
+        tree.child1 = RelatedOrderModel.objects.create(parent=tree.root, name="1")
+        tree.child1_related = OneToOneRelatedOrder.objects.create(
+            relatedmodel=tree.child1, order=0
+        )
+        tree.child2 = RelatedOrderModel.objects.create(parent=tree.root, name="2")
+        tree.child2_related = OneToOneRelatedOrder.objects.create(
+            relatedmodel=tree.child2, order=1
+        )
+        tree.child1_1 = RelatedOrderModel.objects.create(parent=tree.child1, name="1-1")
+        tree.child1_1_related = OneToOneRelatedOrder.objects.create(
+            relatedmodel=tree.child1_1, order=0
+        )
+        tree.child2_1 = RelatedOrderModel.objects.create(parent=tree.child2, name="2-1")
+        tree.child2_1_related = OneToOneRelatedOrder.objects.create(
+            relatedmodel=tree.child2_1, order=0
+        )
+        tree.child2_2 = RelatedOrderModel.objects.create(parent=tree.child2, name="2-2")
+        tree.child2_2_related = OneToOneRelatedOrder.objects.create(
+            relatedmodel=tree.child2_2, order=1
+        )
+
+        nodes = RelatedOrderModel.objects.pre_filter(related__order=0)
+        self.assertEqual(
+            list(nodes),
+            [
+                tree.root,
+                tree.child1,
+                tree.child1_1,
+            ],
+        )
+
+    def test_pre_filter_with_order(self):
+        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+
+        tree.root = MultiOrderedModel.objects.create(
+            name="root", first_position=1,
+        )
+        tree.child1 = MultiOrderedModel.objects.create(
+            parent=tree.root, first_position=0, second_position=1, name="1"
+        )
+        tree.child2 = MultiOrderedModel.objects.create(
+            parent=tree.root, first_position=1, second_position=0, name="2"
+        )
+        tree.child1_1 = MultiOrderedModel.objects.create(
+            parent=tree.child1, first_position=1, second_position=1, name="1-1"
+        )
+        tree.child2_1 = MultiOrderedModel.objects.create(
+            parent=tree.child2, first_position=1, second_position=1, name="2-1"
+        )
+        tree.child2_2 = MultiOrderedModel.objects.create(
+            parent=tree.child2, first_position=1, second_position=0, name="2-2"
+        )
+
+        nodes = (
+            MultiOrderedModel.objects
+            .pre_filter(first_position__gt=0)
+            .order_siblings_by("-second_position")
+        )
+        self.assertEqual(
+            list(nodes),
+            [
+                tree.root,
+                tree.child2,
+                tree.child2_1,
+                tree.child2_2,
+            ],
+        )

--- a/tree_queries/compiler.py
+++ b/tree_queries/compiler.py
@@ -3,6 +3,7 @@ from django.db.models import Value, F, Window, Expression, QuerySet
 from django.db.models.functions import RowNumber
 from django.db.models.sql.compiler import SQLCompiler
 from django.db.models.sql.query import Query
+import django
 
 
 SEPARATOR = "\x1f"
@@ -166,17 +167,17 @@ class TreeCompiler(SQLCompiler):
         
         # Convert strings to expressions. This is to maintain backwards compatibility
         # with Django versions < 4.1
-        base_order = []
-        for field in order_fields:
-            if isinstance(field, Expression):
-                base_order.append(field)
-            elif isinstance(field, str):
-                if field[0] == "-":
-                    base_order.append(F(field[1:]).desc())
-                else:
-                    base_order.append(F(field).asc())
-        order_fields = base_order
-        # End of back compat code
+        if django.VERSION < (4, 1):
+            base_order = []
+            for field in order_fields:
+                if isinstance(field, Expression):
+                    base_order.append(field)
+                elif isinstance(field, str):
+                    if field[0] == "-":
+                        base_order.append(F(field[1:]).desc())
+                    else:
+                        base_order.append(F(field).asc())
+            order_fields = base_order
 
         # Get the rank table query
         rank_table_query = self.query.get_rank_table_query()

--- a/tree_queries/query.py
+++ b/tree_queries/query.py
@@ -27,6 +27,7 @@ class TreeQuerySet(models.QuerySet):
         """
         if tree_fields:
             self.query.__class__ = TreeQuery
+            self.query._setup_query()
         else:
             self.query.__class__ = Query
         return self
@@ -45,7 +46,32 @@ class TreeQuerySet(models.QuerySet):
         to order tree siblings by those model fields
         """
         self.query.__class__ = TreeQuery
+        self.query._setup_query()
         self.query.sibling_order = order_by
+        return self
+
+    def pre_filter(self, **filter):
+        """
+        Sets TreeQuery pre_filter attribute
+
+        Pass a dict of fields and their values to filter by
+        """
+        self.query.__class__ = TreeQuery
+        self.query._setup_query()
+        filter_tuple = (True, filter)
+        self.query.pre_filter.append(filter_tuple)
+        return self
+    
+    def pre_exclude(self, **filter):
+        """
+        Sets TreeQuery pre_filter attribute
+
+        Pass a dict of fields and their values to filter by
+        """
+        self.query.__class__ = TreeQuery
+        self.query._setup_query()
+        exclude_tuple = (False, filter)
+        self.query.pre_filter.append(exclude_tuple)
         return self
 
     def as_manager(cls, *, with_tree_fields=False):  # noqa: N805

--- a/tree_queries/query.py
+++ b/tree_queries/query.py
@@ -50,28 +50,28 @@ class TreeQuerySet(models.QuerySet):
         self.query.sibling_order = order_by
         return self
 
-    def pre_filter(self, **filter):
+    def tree_filter(self, *Q_objects, **filter):
         """
-        Sets TreeQuery pre_filter attribute
+        Sets TreeQuery tree_filter attribute
 
         Pass a dict of fields and their values to filter by
         """
         self.query.__class__ = TreeQuery
         self.query._setup_query()
-        filter_tuple = (True, filter)
-        self.query.pre_filter.append(filter_tuple)
+        filter_tuple = (True, Q_objects, filter)
+        self.query.tree_filter.append(filter_tuple)
         return self
     
-    def pre_exclude(self, **filter):
+    def tree_exclude(self, *Q_objects, **filter):
         """
-        Sets TreeQuery pre_filter attribute
+        Sets TreeQuery tree_filter attribute
 
         Pass a dict of fields and their values to filter by
         """
         self.query.__class__ = TreeQuery
         self.query._setup_query()
-        exclude_tuple = (False, filter)
-        self.query.pre_filter.append(exclude_tuple)
+        exclude_tuple = (False, Q_objects, filter)
+        self.query.tree_filter.append(exclude_tuple)
         return self
 
     def as_manager(cls, *, with_tree_fields=False):  # noqa: N805

--- a/tree_queries/query.py
+++ b/tree_queries/query.py
@@ -50,28 +50,32 @@ class TreeQuerySet(models.QuerySet):
         self.query.sibling_order = order_by
         return self
 
-    def tree_filter(self, *Q_objects, **filter):
+    def tree_filter(self, *args, **kwargs):
         """
-        Sets TreeQuery tree_filter attribute
+        Adds a filter to the TreeQuery rank_table_query
 
-        Pass a dict of fields and their values to filter by
+        Takes the same arguements as a Django QuerySet .filter()
         """
         self.query.__class__ = TreeQuery
         self.query._setup_query()
-        filter_tuple = (True, Q_objects, filter)
-        self.query.tree_filter.append(filter_tuple)
+        self.query.rank_table_query = (
+            self.query.rank_table_query
+            .filter(*args, **kwargs)
+        )
         return self
     
-    def tree_exclude(self, *Q_objects, **filter):
+    def tree_exclude(self, *args, **kwargs):
         """
-        Sets TreeQuery tree_filter attribute
+        Adds a filter to the TreeQuery rank_table_query
 
-        Pass a dict of fields and their values to filter by
+        Takes the same arguements as a Django QuerySet .exclude()
         """
         self.query.__class__ = TreeQuery
         self.query._setup_query()
-        exclude_tuple = (False, Q_objects, filter)
-        self.query.tree_filter.append(exclude_tuple)
+        self.query.rank_table_query = (
+            self.query.rank_table_query
+            .exclude(*args, **kwargs)
+        )
         return self
 
     def as_manager(cls, *, with_tree_fields=False):  # noqa: N805


### PR DESCRIPTION
* Update query.py
-Add `pre_filter` and `pre_exclude` methods to TreeQuerySet.
-Make query methods call `_setup_query` to deal with sibling order and pre_filter persistence issues.

* Update compiler.py
-Replace the `get_sibling_order_params` with `get_rank_table_params` to support early tree filtering.
-Change `sibling_order` and `pre_filter` from class variables to variables that have to be initiated by `_setup_query` so that they don't persist between user queries.
-Handle pre_filter params by passing them to the django backend.

* Update test_queries.py
-Added tests for the `pre_filter` and `pre_exclude` methods.