### PR TITLE
Refs #126: Don't crash on NULL values in tree columns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Change log
 Next version
 ~~~~~~~~~~~~
 
+- Fixed a crash in ``TreeArrayField.from_db_value()`` when a nullable field is
+  used as a custom tree field (``tree_fields()``) or as the sibling ordering
+  field and has a ``NULL`` value: MySQL/MariaDB's ``CONCAT()`` propagates
+  ``NULL`` through the whole tree column once one is encountered, and
+  PostgreSQL's native arrays keep the ``NULL`` as an element. Both cases
+  crashed ``from_db_value()`` since it assumed every element could be
+  converted to ``int``.
+
 
 0.26 (2026-09-07)
 ~~~~~~~~~~~~~~~~~

--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -1193,6 +1193,31 @@ class TestTreeQueries:
         # ids = [obj.tree_pks for obj in Model.objects.tree_fields(tree_pks="parent_id")]
         # self.assertEqual(ids[0], [""])
 
+    def test_tree_fields_with_null_value(self):
+        """A NULL source column doesn't crash from_db_value() (#126)"""
+        category = AlwaysTreeQueryModelCategory.objects.create()
+        root = AlwaysTreeQueryModel.objects.create(name="root")
+        child = AlwaysTreeQueryModel.objects.create(
+            name="child", parent=root, category=category
+        )
+        AlwaysTreeQueryModel.objects.create(name="grandchild", parent=child)
+
+        qs = AlwaysTreeQueryModel.objects.tree_fields(tree_category="category")
+        categories = {obj.name: obj.tree_category for obj in qs}
+
+        if connections[AlwaysTreeQueryModel.objects.db].vendor == "postgresql":
+            # Native arrays keep NULL as None among otherwise-int elements.
+            assert categories["root"] == [None]
+            assert categories["child"] == [None, category.pk]
+            assert categories["grandchild"] == [None, category.pk, None]
+        else:
+            # MySQL/sqlite join the values into a separator-delimited string
+            # and can't tell NULL apart from an empty string there, so the
+            # whole (non-int) list is returned as-is instead of crashing.
+            assert categories["root"] == [""]
+            assert categories["child"] == ["", str(category.pk)]
+            assert categories["grandchild"] == ["", str(category.pk), ""]
+
     def test_invalid_sibling_order_type(self):
         """Test that invalid sibling order types raise TypeError"""
         self.create_tree()

--- a/tree_queries/compiler.py
+++ b/tree_queries/compiler.py
@@ -31,6 +31,10 @@ class TreeArrayField(Field):
         super().__init__(*args, **kwargs)
 
     def from_db_value(self, value, expression, connection):
+        if value is None:
+            # A nullable source column can make the whole value NULL (#126).
+            return None
+
         if isinstance(value, str):
             # MySQL/MariaDB and sqlite3 do not support arrays. Split the value
             # on the ASCII unit separator (chr(31)).
@@ -38,9 +42,9 @@ class TreeArrayField(Field):
             value = value.split(SEPARATOR)[1:-1]
 
         try:
-            # Either all values are convertible to int or don't bother
-            return [int(v) for v in value]  # Maybe Field.to_python()?
-        except ValueError:
+            # None stays None; otherwise all values convertible to int or don't bother.
+            return [None if v is None else int(v) for v in value]
+        except (TypeError, ValueError):
             return value
 
 
@@ -410,7 +414,7 @@ class TreeCompiler(SQLCompiler):
         SELECT
             {tree_fields_initial}0,
             CAST(CONCAT("{sep}", T.{pk}, "{sep}") AS char(1000)),
-            CAST(CONCAT("{sep}", LPAD(CONCAT(T.`{order_field}`, "{sep}"), 20, "0")) AS char(1000)),
+            CAST(CONCAT("{sep}", LPAD(CONCAT(IFNULL(T.`{order_field}`, ""), "{sep}"), 20, "0")) AS char(1000)),
             T.{pk}
         FROM {db_table} T
         WHERE T.`{parent}` IS NULL
@@ -420,7 +424,7 @@ class TreeCompiler(SQLCompiler):
         SELECT
             {tree_fields_recursive}__tree.tree_depth + 1,
             CONCAT(__tree.tree_path, T.{pk}, "{sep}"),
-            CONCAT(__tree.tree_ordering, LPAD(CONCAT(T.`{order_field}`, "{sep}"), 20, "0")),
+            CONCAT(__tree.tree_ordering, LPAD(CONCAT(IFNULL(T.`{order_field}`, ""), "{sep}"), 20, "0")),
             T.{pk}
         FROM {db_table} T, __tree
         WHERE __tree.tree_pk = T.`{parent}`
@@ -653,8 +657,11 @@ class TreeCompiler(SQLCompiler):
             cte_recursive = '__tree.{name} || printf("%%s{sep}", {column}), '
         elif self.connection.vendor == "mysql":
             cte = self.CTE_MYSQL_SIMPLE if not use_rank_table else self.CTE_MYSQL
-            cte_initial = 'CAST(CONCAT("{sep}", {column}, "{sep}") AS char(1000)), '
-            cte_recursive = 'CONCAT(__tree.{name}, {column}, "{sep}"), '
+            # IFNULL avoids CONCAT() nulling the whole value on a NULL column (#126).
+            cte_initial = (
+                'CAST(CONCAT("{sep}", IFNULL({column}, ""), "{sep}") AS char(1000)), '
+            )
+            cte_recursive = 'CONCAT(__tree.{name}, IFNULL({column}, ""), "{sep}"), '
 
         tree_fields = self.query.get_tree_fields()
         qn = self.connection.ops.quote_name


### PR DESCRIPTION
A nullable field used as a custom tree field or as the sibling ordering field can produce a NULL value for some node: MySQL/MariaDB's CONCAT() then nulls the whole tree column for that node and every descendant, and PostgreSQL's native arrays keep the NULL as an element. TreeArrayField.from_db_value() assumed every value could be converted to int and crashed with a TypeError in both cases.